### PR TITLE
Fix typo . -> /

### DIFF
--- a/Step03.md
+++ b/Step03.md
@@ -28,7 +28,7 @@ func (s *Service) SetupAPI(e *echo.Echo) error {
 }
 ```
 
-**cmd.main.go**
+**cmd/main.go**
 
 ```go
 package main


### PR DESCRIPTION
It seems like it meant to be a path.